### PR TITLE
Auto-update weights for 2025-01-19-17-30-42

### DIFF
--- a/substrate/frame/assets/src/weights.rs
+++ b/substrate/frame/assets/src/weights.rs
@@ -140,7 +140,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Measured:  `71 + c * (208 ±0)`
 		//  Estimated: `3675 + c * (2609 ±0)`
 		// Minimum execution time: 20_846_000 picoseconds.
-		Weight::from_parts(21_195_000, 3675)
+		Weight::from_parts(41_195_000, 3675)
 			// Standard Error: 13_008
 			.saturating_add(Weight::from_parts(15_076_064, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(2_u64))


### PR DESCRIPTION
Auto-update weights for $DATE\n\n<details>\n<summary>Weight Changes Analysis</summary>\n\n| File                                                                                                 | Extrinsic             | Old | New | Change [%] |
|------------------------------------------------------------------------------------------------------|-----------------------|-----|-----|------------|
| cumulus/pallets/collator-selection/src/weights.rs                                                    | leave_intent          | -   | -   | ERROR      |
| cumulus/pallets/collator-selection/src/weights.rs                                                    | new_session           | -   | -   | ERROR      |
| cumulus/pallets/collator-selection/src/weights.rs                                                    | register_as_candidate | -   | -   | ERROR      |
| cumulus/pallets/collator-selection/src/weights.rs                                                    | set_invulnerables     | -   | -   | ERROR      |
| cumulus/pallets/collator-selection/src/weights.rs                                                    | take_candidate_slot   | -   | -   | ERROR      |
| cumulus/pallets/collator-selection/src/weights.rs                                                    | update_bond           | -   | -   | ERROR      |
| cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/pallet_collator_selection.rs         | take_candidate_slot   | -   | -   | ERROR      |
| cumulus/parachains/runtimes/assets/asset-hub-rococo/src/weights/pallet_collator_selection.rs         | update_bond           | -   | -   | ERROR      |
| cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_collator_selection.rs        | take_candidate_slot   | -   | -   | ERROR      |
| cumulus/parachains/runtimes/assets/asset-hub-westend/src/weights/pallet_collator_selection.rs        | update_bond           | -   | -   | ERROR      |
| cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_collator_selection.rs   | take_candidate_slot   | -   | -   | ERROR      |
| cumulus/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_collator_selection.rs   | update_bond           | -   | -   | ERROR      |
| cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/pallet_collator_selection.rs  | take_candidate_slot   | -   | -   | ERROR      |
| cumulus/parachains/runtimes/bridge-hubs/bridge-hub-westend/src/weights/pallet_collator_selection.rs  | update_bond           | -   | -   | ERROR      |
| cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_collator_selection.rs | take_candidate_slot   | -   | -   | ERROR      |
| cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_collator_selection.rs | update_bond           | -   | -   | ERROR      |
| cumulus/parachains/runtimes/collectives/collectives-westend/src/weights/pallet_preimage.rs           | ensure_updated        | -   | -   | ERROR      |
| cumulus/parachains/runtimes/people/people-rococo/src/weights/pallet_collator_selection.rs            | take_candidate_slot   | -   | -   | ERROR      |
| cumulus/parachains/runtimes/people/people-rococo/src/weights/pallet_collator_selection.rs            | update_bond           | -   | -   | ERROR      |
| cumulus/parachains/runtimes/people/people-westend/src/weights/pallet_collator_selection.rs           | take_candidate_slot   | -   | -   | ERROR      |
| cumulus/parachains/runtimes/people/people-westend/src/weights/pallet_collator_selection.rs           | update_bond           | -   | -   | ERROR      |
| polkadot/runtime/westend/src/weights/pallet_preimage.rs                                              | ensure_updated        | -   | -   | ERROR      |
| substrate/frame/election-provider-support/src/weights.rs                                             | phragmen              | -   | -   | ERROR      |
| substrate/frame/election-provider-support/src/weights.rs                                             | phragmms              | -   | -   | ERROR      |\n\n</details>